### PR TITLE
Handle multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WhisperDialog.newDialog();
 ![In Action](https://i.gyazo.com/89ea3a782c46e1da89a5351e44987d6c.gif)
 
 Advanced Use
-1. user : `USER ID TO SEND WHISPER DIALOG TO`,
+1. users : `ARRAY OF USER IDS TO SEND WHISPER DIALOG TO`,
 2. content : `CONTENT OF THE DIALOG`,
 3. title : `TITLE OF THE DIALOG`,
 4. skipDialog : true/false, //will skip Client Dialog, automatically pushing information to user

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,10 +8,11 @@
   "wd.dialog.nullUserError" : "Cannot send dialog to null user",
   "wd.dialog.noUserError" : "No other user is connected.",
   "wd.dialog.notGMError" : "This module is restricted to GM use only.",
+  "wd.dialog.userRequired" : "You must select at least 1 user.",
 
   "wd.dialog.defaultTitle" : "For your eyes only.",
 
-  "wd.dialog.content.chooseUser" : "Choose User:",
+  "wd.dialog.content.chooseUser" : "Whisper Users:",
   "wd.dialog.content.chatWhisper" : "Log to chat",
   "wd.dialog.content.message" : "Message:",
 

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -126,7 +126,7 @@ export function recieveData({ user, title, content, sender } = {})
   Logger.debug("Dialog | Recieve Data | Data Check | ", user, title, content, sender);
   const fixedContent = `<h3>${content.replace(/(?:\r\n|\r|\n)/g, '<br>')}</h3>`;
 
-  if(user.includes(game.userId))
+  if(game.userId === user)
   {
     Logger.debug(`Dialog | Receive data | Conditional Statment TRUE`);
 
@@ -137,7 +137,7 @@ export function recieveData({ user, title, content, sender } = {})
     let options = {
       users : [],
       content : fixedContent, 
-      title : title,
+      title : fixedTitle,
       emit : false,
       hideButtons : true,
     }


### PR DESCRIPTION
Send out whispers to multiple targets.
Selected token will have their players automatically selected.

Current issue is that the selected users are very difficult to see when the whisper users box is unfocused.