### PR TITLE
Dialog Box design

### DIFF
--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -85,7 +85,7 @@ export function newDialog({content = ``, title = ``, whisper = [], skipDialog = 
         </label>
       </div>
 
-      <div>${i18n("wd.dialog.content.message")} <textarea name="content" rows="6" style="width: 250px">${content}</textarea></div>
+      <div>${i18n("wd.dialog.content.message")} <textarea name="content" rows="6" style="width: 100%">${content}</textarea></div>
     </div>
     <br />
     `;


### PR DESCRIPTION
Hello, 
when i use dialog box, some formatting users are line breaked. 
See : 
![dialogBox](https://user-images.githubusercontent.com/65294435/107611308-02791e00-6c44-11eb-8815-bed23bc5f84c.PNG)

I propose to make this change on dialog.js : li 88 width of 100% instead of 250px